### PR TITLE
READMEのDB設計でusersテーブルのカラムを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 |nickname|string|null: false|
 |email|string|null false|
 |password|string|null: false|
+|first_name|string|null: false|
+|family_name|string|null: false|
+|first_name_kana|string|null: false|
+|family_name_kana|string|null: false|
+|birthday|date|null: false|
 
 ### Association
 - has_many: profiles, dependent: :destroy
@@ -15,12 +20,12 @@
 - has_one :credit_card, dependent: :destroy
 
 
-## profilesテーブル
+## addressesテーブル
+
 |first_name|string|null: false|
 |family_name|string|null: false|
 |first_name_kana|string|null: false|
 |family_name_kana|string|null: false|
-|birthday|date|null: false|
 |post_code|integer(7)|null: false|
 |prefecture_code|integer|null: false|
 |city|string|null: false|
@@ -31,7 +36,7 @@
 
 ### Association
 - belongs_to :user
-
+- Gem：jp_prefecture
 
 ## productsテーブル
 |Column|Type|Option|


### PR DESCRIPTION
## What
usersテーブルに、ユーザーのnameにまつわるカラムを追加した。
また、「profilesテーブル」の名前を「adressesテーブル」に変更した。

ER図
https://app.lucidchart.com/documents/edit/0943f5ea-3ba8-4407-85b9-989f7abf6b6a/0_0?beaconFlowId=1E9038292D4E00E5

## Why
deviseの仕様上、ユーザーのnameにまつわるカラムはusersテーブルにあるのが望ましいため。
また、profilesテーブルの名前変更は、より機能に沿った名前にするため。