### PR TITLE
完了ページの作成＆エラーメッセージの作成＆画像にまつわるエラーの是正

### DIFF
--- a/app/assets/stylesheets/_items-finish.scss
+++ b/app/assets/stylesheets/_items-finish.scss
@@ -1,0 +1,41 @@
+.finishHead {
+  width: 100%;
+  padding: 40px 0;
+  &__logo {
+    max-width: 456px;
+    margin: 0 auto;
+    text-align: center;
+    img {
+      width: 185px;
+    }
+  }
+}
+
+.finish {
+  width: 100%;
+  .finish__frame {
+    max-width: 750px;
+    margin: 0 auto;
+    &__message {
+      font-size: 32px;
+      text-align: center;
+    }
+    &__btns {
+      .top_page_link {
+        width: 250px;
+        margin: 50px auto 30px;
+        font-size: 18px;
+        text-align: center;
+        border-radius: 20px;
+        color: #fff;
+        background-color: #3CCACE;
+        a {
+          display: block;
+          padding: 15px;
+          text-decoration: none;
+          color: #fff;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,4 +13,5 @@
 @import "credit_cards/show";
 @import "credit_cards/create";
 @import "credit_cards/destroy";
+@import "layouts/error_messages";
 @import "flash";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "variables";
 @import "items";
 @import "items-show";
+@import "items-finish";
 @import "sell";
 @import "buy";
 @import "credit_cards/new";

--- a/app/assets/stylesheets/layouts/_error_messages.scss
+++ b/app/assets/stylesheets/layouts/_error_messages.scss
@@ -1,0 +1,7 @@
+.alert-models {
+  color:#262626; 
+  background:#FFEBE8;
+  text-align: center;
+  border:2px solid #990000;
+  padding:12px; font-weight:850;
+}

--- a/app/assets/stylesheets/layouts/_error_messages.scss
+++ b/app/assets/stylesheets/layouts/_error_messages.scss
@@ -3,5 +3,6 @@
   background:#FFEBE8;
   text-align: center;
   border:2px solid #990000;
-  padding:12px; font-weight:850;
+  padding:12px;
+  font-weight:850;
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,8 +24,9 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
     else
+      @item.item_imgs.new
+      @category_parent =  Category.where("ancestry is null")
       render :new
     end
   end
@@ -39,15 +40,14 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to root_path
     else
+      @category_parent =  Category.where("ancestry is null")
       render :edit
     end
   end
 
   def destroy
     @item.destroy
-    redirect_to root_path
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,15 +13,17 @@ class Item < ApplicationRecord
 
   accepts_nested_attributes_for :item_imgs, allow_destroy: true
 
+  validates :item_imgs, presence: true
   validate :item_imgs_number
   validates :name, presence: true,
                    length: { maximum: 40 }
   validates :introduction, presence: true,
                            length: { maximum: 1000 }
-
+  validates :price, presence: true,
+                    numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+                   
 
   with_options presence: true do
-    validates :price
     validates :item_condition
     validates :postage_payer
     validates :prefecture_code
@@ -38,7 +40,7 @@ class Item < ApplicationRecord
   private
 
   def item_imgs_number
-    errors.add(:item_imgs, "を1つ以上指定して下さい") if item_imgs.size < 1
+    errors.add(:item_imgs, "は1つ以上必要です") if item_imgs.size < 1
     errors.add(:item_imgs, "は3個までです") if item_imgs.size > 3
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,15 +13,19 @@ class Item < ApplicationRecord
 
   accepts_nested_attributes_for :item_imgs, allow_destroy: true
 
+  validate :item_imgs_number
+  validates :name, presence: true,
+                   length: { maximum: 40 }
+  validates :introduction, presence: true,
+                           length: { maximum: 1000 }
+
+
   with_options presence: true do
-    validates :name
-    validates :introduction
     validates :price
     validates :item_condition
     validates :postage_payer
     validates :prefecture_code
     validates :preparation_day
-    validates :item_imgs
     validates :category
     validates :seller
   end
@@ -30,8 +34,6 @@ class Item < ApplicationRecord
     sale: 1,
     sold: 2
   }
-
-  validate :item_imgs_number
 
   private
 

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -5,6 +5,7 @@
         = image_tag "logo.png"        
     
     = form_with model: @item, class: "Sell__page__body", local: true do |f|
+      = render 'layouts/error_messages', model: f.object
       .Sell__page__body__img
         .Sell__page__body__img__label
           出品画像 

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,0 +1,10 @@
+.finish
+  %header.finishHead
+    .finishHead__logo
+      = link_to image_tag("logo.png", alt: "FURIMA"), root_path
+  .finish__frame
+    .finish__frame__message
+      登録が完了しました。
+    %ul.finish__frame__btns
+      %li.top_page_link
+        = link_to "トップページへ", root_path, class: "top_page_link__btn"

--- a/app/views/items/destroy.html.haml
+++ b/app/views/items/destroy.html.haml
@@ -1,0 +1,10 @@
+.finish
+  %header.finishHead
+    .finishHead__logo
+      = link_to image_tag("logo.png", alt: "FURIMA"), root_path
+  .finish__frame
+    .finish__frame__message
+      削除が完了しました。
+    %ul.finish__frame__btns
+      %li.top_page_link
+        = link_to "トップページへ", root_path, class: "top_page_link__btn"

--- a/app/views/items/update.html.haml
+++ b/app/views/items/update.html.haml
@@ -1,0 +1,10 @@
+.finish
+  %header.finishHead
+    .finishHead__logo
+      = link_to image_tag("logo.png", alt: "FURIMA"), root_path
+  .finish__frame
+    .finish__frame__message
+      編集が完了しました。
+    %ul.finish__frame__btns
+      %li.top_page_link
+        = link_to "トップページへ", root_path, class: "top_page_link__btn"

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,0 +1,5 @@
+-if model.errors.any? 
+  .alert-models
+    %ul
+      -model.errors.full_messages.each do |message|
+        %li= message

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -208,3 +208,11 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+
+  activerecord:
+    attributes:
+      item:
+        name: 名前
+        introduction: 商品の説明
+        price: 値段
+        item_imgs: 画像


### PR DESCRIPTION
#What
商品登録、編集、削除後のビューページを作成。
商品登録でバリデーションに引っかかったときのエラーメッセージを作成。
商品編集のとき、画像が０枚でも登録できてしまう問題を是正。

#Why
アプリケーションのクオリティを上げるため。